### PR TITLE
Fixed bug with removing jailed validator from active validator set

### DIFF
--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -201,6 +201,7 @@ contract Staking is IStaking, InjectorContextHolder {
         // update validator status
         validator.status = ValidatorStatus.Active;
         _validatorsMap[validatorAddress] = validator;
+        _activeValidatorsList.push(validatorAddress);
     }
 
     function _totalDelegatedToValidator(Validator memory validator) internal view returns (uint256) {
@@ -751,6 +752,7 @@ contract Staking is IStaking, InjectorContextHolder {
         if (slashesCount == _chainConfigContract.getFelonyThreshold()) {
             validator.jailedBefore = _currentEpoch() + _chainConfigContract.getValidatorJailEpochLength();
             validator.status = ValidatorStatus.Jail;
+            _removeValidatorFromActiveList(validatorAddress);
             _validatorsMap[validatorAddress] = validator;
             emit ValidatorJailed(validatorAddress, epoch);
         }


### PR DESCRIPTION
There is a bug that causes issue with removing jailed validator from active validator set and such validator continues to produce blocks. The issue appeared when we split validator set into two parts: active and non active, for preventing some ddos attacks on the consensus. This PR fixes this issue. Unit tests for reproducing this is also added.

After merge staking system smart contract should be updated using runtime upgrade and governance mechanism.