### PR TITLE
Fixed bug with calculating governance's voting power for validators with changed owners

### DIFF
--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -23,7 +23,7 @@ contract Governance is InjectorContextHolder, GovernorCountingSimple, GovernorSe
     }
 
     function getVotingPower(address validator) external view returns (uint256) {
-        return _validatorVotingPowerAt(validator, block.number);
+        return _validatorOwnerVotingPowerAt(validator, block.number);
     }
 
     function proposeWithCustomVotingPeriod(
@@ -76,15 +76,15 @@ contract Governance is InjectorContextHolder, GovernorCountingSimple, GovernorSe
     }
 
     function getVotes(address account, uint256 blockNumber) public view override returns (uint256) {
-        return _validatorVotingPowerAt(account, blockNumber);
+        return _validatorOwnerVotingPowerAt(account, blockNumber);
     }
 
-    function _validatorVotingPowerAt(address validatorOwner, uint256 blockNumber) internal view returns (uint256) {
+    function _validatorOwnerVotingPowerAt(address validatorOwner, uint256 blockNumber) internal view returns (uint256) {
         address validator = _stakingContract.getValidatorByOwner(validatorOwner);
-        // only active validators can vote
-        if (!_stakingContract.isValidatorActive(validator)) {
-            return 0;
-        }
+        return _validatorVotingPowerAt(validator, blockNumber);
+    }
+
+    function _validatorVotingPowerAt(address validator, uint256 blockNumber) internal view returns (uint256) {
         // find validator votes at block number
         uint64 epoch = uint64(blockNumber / _chainConfigContract.getEpochBlockInterval());
         (,,uint256 totalDelegated,,,,,,) = _stakingContract.getValidatorStatusAtEpoch(validator, epoch);

--- a/test/governance.js
+++ b/test/governance.js
@@ -1,0 +1,33 @@
+/** @var artifacts {Array} */
+/** @var web3 {Web3} */
+/** @function contract */
+/** @function it */
+/** @function before */
+/** @var assert */
+
+const {newMockContract, waitForNextEpoch} = require('./helper')
+
+contract("Governance", async (accounts) => {
+  const [owner, validator1, validator2, owner1, owner2] = accounts;
+  it("voting power is well distributed for validators with different owners", async () => {
+    const {parlia, governance} = await newMockContract(owner, {
+      genesisValidators: [validator1, validator2],
+    });
+    await parlia.delegate(validator1, {value: '1000000000000000000', from: owner});
+    await parlia.delegate(validator2, {value: '1000000000000000000', from: owner});
+    await waitForNextEpoch(parlia);
+    // let's check voting supply and voting powers for validators
+    let votingSupply = await governance.getVotingSupply();
+    assert.equal(votingSupply.toString(), '2000000000000000000');
+    assert.equal((await governance.getVotingPower(validator1)).toString(), '1000000000000000000');
+    assert.equal((await governance.getVotingPower(validator2)).toString(), '1000000000000000000');
+    // now lets change validator owner
+    await parlia.changeValidatorOwner(validator1, owner1, {from: validator1});
+    await parlia.changeValidatorOwner(validator2, owner2, {from: validator2});
+    // let's re-check voting supply and voting powers for validators, it should be the same
+    votingSupply = await governance.getVotingSupply();
+    assert.equal(votingSupply.toString(), '2000000000000000000');
+    assert.equal((await governance.getVotingPower(owner1)).toString(), '1000000000000000000');
+    assert.equal((await governance.getVotingPower(owner2)).toString(), '1000000000000000000');
+  });
+});


### PR DESCRIPTION
This PR contains fix for the governance that might cause governance outage in case of 2/3 of validators change their validator owner. Unit tests added to cover this test-case.