### PR TITLE
Fixed bug with redelegate calculation and total delegation in some cases

### DIFF
--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -246,8 +246,6 @@ contract Staking is IStaking, InjectorContextHolder {
         if (snapshot.totalDelegated > 0) {
             return snapshot;
         }
-        // make sure modification of prev epoch is impossible
-        require(epoch >= validator.changedAt, "epoch underflow");
         // find previous snapshot to copy parameters from it
         ValidatorSnapshot memory lastModifiedSnapshot = _validatorSnapshots[validator.validatorAddress][validator.changedAt];
         // last modified snapshot might store zero value, for first delegation it might happen and its not critical

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -597,8 +597,8 @@ contract Staking is IStaking, InjectorContextHolder {
         require(_validatorsMap[validatorAddress].status == ValidatorStatus.Pending, "not pending");
         _activeValidatorsList.push(validatorAddress);
         validator.status = ValidatorStatus.Active;
-        _validatorsMap[validatorAddress] = validator;
         ValidatorSnapshot storage snapshot = _touchValidatorSnapshot(validator, _nextEpoch());
+        _validatorsMap[validatorAddress] = validator;
         emit ValidatorModified(validatorAddress, validator.ownerAddress, uint8(validator.status), snapshot.commissionRate);
     }
 
@@ -611,8 +611,8 @@ contract Staking is IStaking, InjectorContextHolder {
         require(_validatorsMap[validatorAddress].status == ValidatorStatus.Active, "not active");
         _removeValidatorFromActiveList(validatorAddress);
         validator.status = ValidatorStatus.Pending;
-        _validatorsMap[validatorAddress] = validator;
         ValidatorSnapshot storage snapshot = _touchValidatorSnapshot(validator, _nextEpoch());
+        _validatorsMap[validatorAddress] = validator;
         emit ValidatorModified(validatorAddress, validator.ownerAddress, uint8(validator.status), snapshot.commissionRate);
     }
 
@@ -634,8 +634,8 @@ contract Staking is IStaking, InjectorContextHolder {
         delete _validatorOwners[validator.ownerAddress];
         validator.ownerAddress = newOwner;
         _validatorOwners[newOwner] = validatorAddress;
-        _validatorsMap[validatorAddress] = validator;
         ValidatorSnapshot storage snapshot = _touchValidatorSnapshot(validator, _nextEpoch());
+        _validatorsMap[validatorAddress] = validator;
         emit ValidatorModified(validator.validatorAddress, validator.ownerAddress, uint8(validator.status), snapshot.commissionRate);
     }
 


### PR DESCRIPTION
- Removed `gasleft()` checks because if affects `StakingPool` logic sometimes and MetaMask can't properly calculate gas consumption
- Fixed bug with saving recent validator state after activation or deactivation