### PR TITLE
feat(BLK-2533): Add toggle whitelist functionality to DeployerProxy.sol

### DIFF
--- a/contracts/DeployerProxy.sol
+++ b/contracts/DeployerProxy.sol
@@ -65,6 +65,9 @@ contract DeployerProxy is IDeployerProxy, InjectorContextHolder {
     }
 
     function isDeployer(address account) public override view returns (bool) {
+        if (!_deployerWhitelistEnabled) {
+            return true;
+        }
         return _contractDeployers[account].exists;
     }
 

--- a/contracts/DeployerProxy.sol
+++ b/contracts/DeployerProxy.sol
@@ -141,7 +141,7 @@ contract DeployerProxy is IDeployerProxy, InjectorContextHolder {
         // emit event
         emit ContractDeployed(deployer, impl);
         // make new contract deployer as well
-        if (!_contractDeployers[impl].exists) {
+        if (!isDeployer(impl)) {
             _addDeployer(impl);
         }
     }

--- a/contracts/DeployerProxy.sol
+++ b/contracts/DeployerProxy.sol
@@ -75,11 +75,11 @@ contract DeployerProxy is IDeployerProxy, InjectorContextHolder {
         return _contractDeployers[account].banned;
     }
 
-    function addDeployer(address account) public onlyFromGovernance virtual override {
+    function addDeployer(address account) public onlyWhenWhitelistEnabled onlyFromGovernance virtual override {
         _addDeployer(account);
     }
 
-    function _addDeployer(address account) internal onlyWhenWhitelistEnabled {
+    function _addDeployer(address account) internal {
         require(!_contractDeployers[account].exists, "Deployer: deployer already exist");
         _contractDeployers[account] = Deployer({
         exists : true,
@@ -89,11 +89,11 @@ contract DeployerProxy is IDeployerProxy, InjectorContextHolder {
         emit DeployerAdded(account);
     }
 
-    function removeDeployer(address account) public onlyFromGovernance virtual override {
+    function removeDeployer(address account) public onlyWhenWhitelistEnabled onlyFromGovernance virtual override {
         _removeDeployer(account);
     }
 
-    function _removeDeployer(address account) internal onlyWhenWhitelistEnabled {
+    function _removeDeployer(address account) internal {
         require(_contractDeployers[account].exists, "Deployer: deployer doesn't exist");
         delete _contractDeployers[account];
         emit DeployerRemoved(account);
@@ -104,8 +104,10 @@ contract DeployerProxy is IDeployerProxy, InjectorContextHolder {
     }
 
     function _banDeployer(address account) internal {
-        require(_contractDeployers[account].exists, "Deployer: deployer doesn't exist");
         require(!_contractDeployers[account].banned, "Deployer: deployer already banned");
+        if (!_contractDeployers[account].exists) {
+            _addDeployer(account);
+        }
         _contractDeployers[account].banned = true;
         emit DeployerBanned(account);
     }

--- a/contracts/tests/FakeDeployerProxy.sol
+++ b/contracts/tests/FakeDeployerProxy.sol
@@ -8,6 +8,10 @@ contract FakeDeployerProxy is DeployerProxy {
     constructor(bytes memory ctor) DeployerProxy(ctor) {
     }
 
+    function toggleDeployerWhitelist(bool state) public override {
+        _toggleDeployerWhitelist(state);
+    }
+
     function addDeployer(address account) public override {
         _addDeployer(account);
     }

--- a/scripts/toggle-deployer-whitelist.js
+++ b/scripts/toggle-deployer-whitelist.js
@@ -1,0 +1,30 @@
+const DeployerProxy = artifacts.require("DeployerProxy");
+const Governance = artifacts.require('Governance');
+
+const GOVERNANCE_ADDRESS = '0x0000000000000000000000000000000000007002';
+const DEPLOYER_PROXY_ADDRESS = '0x0000000000000000000000000000000000007005';
+
+const generate = async () => {
+  const deployerProxy = await DeployerProxy.at(DEPLOYER_PROXY_ADDRESS);
+  const governance = await Governance.at(GOVERNANCE_ADDRESS);
+  const toggleValue = process.env.VALUE === "true";
+
+  console.log(`building toggle deployer whitelist proposal...`);
+
+  const targets = [DEPLOYER_PROXY_ADDRESS]
+  const values = ['0x00']
+  const calldatas = [deployerProxy.contract.methods.toggleDeployerWhitelist(toggleValue).encodeABI()]
+  console.log(calldatas);
+  const input = governance.contract.methods.proposeWithCustomVotingPeriod(targets, values, calldatas, `Toggle deployer whitelist feature ${toggleValue ? "on" : "off"}`, process.env.VOTING_DURATION || '50').encodeABI();
+  console.log('input data for proposal:', input)
+}
+
+module.exports = async function(callback) {
+  try {
+    await generate();
+  } catch (e) {
+    console.error(e);
+  } finally {
+    callback();
+  }
+}

--- a/test/deployer.js
+++ b/test/deployer.js
@@ -104,15 +104,18 @@ contract("DeployerProxy", async (accounts) => {
   it("enable disable deployer whitelist", async () => {
     const {deployer} = await newMockContract(owner);
     assert.equal(await deployer.isDeployerWhitelistEnabled(), true)
+    assert.equal(await deployer.isDeployer('0x0000000000000000000000000000000000000001'), false)
     // disable whitelist
     const r1 = await deployer.toggleDeployerWhitelist(false)
     assert.equal(r1.logs[0].event, 'DeployerWhitelistEnabled')
     assert.equal(r1.logs[0].args.state, false)
     assert.equal(await deployer.isDeployerWhitelistEnabled(), false)
+    assert.equal(await deployer.isDeployer('0x0000000000000000000000000000000000000001'), true)
     // enable whitelist
     const r2 = await deployer.toggleDeployerWhitelist(true)
     assert.equal(r2.logs[0].event, 'DeployerWhitelistEnabled')
     assert.equal(r2.logs[0].args.state, true)
     assert.equal(await deployer.isDeployerWhitelistEnabled(), true)
+    assert.equal(await deployer.isDeployer('0x0000000000000000000000000000000000000001'), false)
   });
 });

--- a/test/deployer.js
+++ b/test/deployer.js
@@ -53,12 +53,28 @@ contract("DeployerProxy", async (accounts) => {
     contract = await deployer.getContractState('0x0000000000000000000000000000000000000222');
     assert.equal(contract.state, '1');
   });
-  it("contract deployment is not possible w/o whitelist", async () => {
+  it("contract deployment is not possible w/o whitelist (WHITELIST ENABLED)", async () => {
     const {deployer} = await newMockContract(owner);
     // try to register w/o whitelist
     await expectError(deployer.registerDeployedContract(owner, '0x0000000000000000000000000000000000000123'), 'Deployer: deployer is not allowed');
     // let owner be a deployer
     await deployer.addDeployer(owner)
+    const r1 = await deployer.registerDeployedContract(owner, '0x0000000000000000000000000000000000000123');
+    assert.equal(r1.logs[0].event, 'ContractDeployed')
+    const contractDeployer = await deployer.getContractState('0x0000000000000000000000000000000000000123');
+    assert.equal(contractDeployer.state, '1')
+    assert.equal(contractDeployer.impl, '0x0000000000000000000000000000000000000123')
+    assert.equal(contractDeployer.deployer, owner)
+  })
+  it("contract deployment is possible w/o whitelist (WHITELIST DISABLED)", async () => {
+    const {deployer} = await newMockContract(owner);
+    // sanity check
+    assert.equal(await deployer.isDeployer(owner), false);
+    assert.equal(await deployer.isDeployerWhitelistEnabled(), true);
+
+    // disable whitelist & try to register
+    await deployer.toggleDeployerWhitelist(false);
+    assert.equal(await deployer.isDeployerWhitelistEnabled(), false);
     const r1 = await deployer.registerDeployedContract(owner, '0x0000000000000000000000000000000000000123');
     assert.equal(r1.logs[0].event, 'ContractDeployed')
     const contractDeployer = await deployer.getContractState('0x0000000000000000000000000000000000000123');
@@ -98,8 +114,14 @@ contract("DeployerProxy", async (accounts) => {
     await deployer.addDeployer(owner);
     const deployerFactory = await TestDeployerFactory.new();
     await deployer.registerDeployedContract(owner, deployerFactory.address);
-    assert.equal(await deployer.isDeployer(owner), true)
-    assert.equal(await deployer.isDeployer(deployerFactory.address), true)
+    assert.equal(await deployer.isDeployer(owner), true);
+    assert.equal(await deployer.isDeployer(deployerFactory.address), true);
+
+    // This should still be true if the whitelist is off
+    await deployer.toggleDeployerWhitelist(false);
+    assert.equal(await deployer.isDeployerWhitelistEnabled(), false);
+    assert.equal(await deployer.isDeployer(owner), true);
+    assert.equal(await deployer.isDeployer(deployerFactory.address), true);
   });
   it("enable disable deployer whitelist", async () => {
     const {deployer} = await newMockContract(owner);


### PR DESCRIPTION
**Changes:**
- Added `toggleDeployerWhitelist()` public method that is only callable from governance.
- Added `_toggleDeployerWhitelist()` internal method that updates the `_deployerWhitelistEnabled` internal instance variable.
- Added `onlyWhenWhitelistEnabled()` modifier, added it to `addDeployer()` and `removeDeployer()` methods.
- Updated `_banDeployer()` method. Add the deployer to `_contractDeployers` if it doesn't exist to keep this function working for when the whitelist feature is off.
- Updated `isDeployer()` method to ignore the whitelist if the feature is off.
- Updated `_registerDeployedContract()` method to ignore the whitelist if the feature is off. 
- Updated unit tests.
- Added script for generating the tx input for toggle deployer whitelist proposal.