### PR TITLE
Added new getValidatorPoolWithoutRewards method to StakingPool contract

### DIFF
--- a/contracts/StakingPool.sol
+++ b/contracts/StakingPool.sol
@@ -16,13 +16,7 @@ contract StakingPool is InjectorContextHolder, IStakingPool {
     event Unstake(address indexed validator, address indexed staker, uint256 amount);
     event Claim(address indexed validator, address indexed staker, uint256 amount);
 
-    struct ValidatorPool {
-        address validatorAddress;
-        uint256 sharesSupply;
-        uint256 totalStakedAmount;
-        uint256 dustRewards;
-        uint256 pendingUnstake;
-    }
+
 
     struct PendingUnstake {
         uint256 amount;
@@ -58,6 +52,12 @@ contract StakingPool is InjectorContextHolder, IStakingPool {
         validatorPool.totalStakedAmount += amountToStake;
         validatorPool.dustRewards += dustRewards;
         return validatorPool;
+    }
+
+    /// @notice Returns validator pool data without rewards being calculated.
+    /// @param validator Validator address.
+    function getValidatorPoolWithoutRewards(address validator) external view returns (ValidatorPool memory) {
+        return _getValidatorPool(validator);
     }
 
     function getRatio(address validator) external view returns (uint256) {

--- a/contracts/interfaces/IStakingPool.sol
+++ b/contracts/interfaces/IStakingPool.sol
@@ -2,6 +2,17 @@
 pragma solidity ^0.8.0;
 
 interface IStakingPool {
+    struct ValidatorPool {
+        address validatorAddress;
+        uint256 sharesSupply;
+        uint256 totalStakedAmount;
+        uint256 dustRewards;
+        uint256 pendingUnstake;
+    }
+
+    function getValidatorPool(address validator) external view returns (ValidatorPool memory);
+
+    function getValidatorPoolWithoutRewards(address validator) external view returns (ValidatorPool memory);
 
     function getStakedAmount(address validator, address staker) external view returns (uint256);
 


### PR DESCRIPTION
We added a new function in the StakingPool contract (getValidatorPoolWithoutRewards) that will allow to grab validatorPool data without going through the calculation of the rewards and pending undelegates and so will be cheaper.