### PR TITLE
fix(BLK-3498): Sherlock #66

### DIFF
--- a/contracts/ChainConfig.sol
+++ b/contracts/ChainConfig.sol
@@ -5,7 +5,7 @@ import "./Injector.sol";
 
 contract ChainConfig is InjectorContextHolder, IChainConfig {
 
-    event ActiveValidatorsLengthChanged(uint32 prevValue, uint32 newValue);
+    event ActiveValidatorsLengthChanged(uint32 prevValue, uint32 newValue, uint64 epoch);
     event EpochBlockIntervalChanged(uint32 prevValue, uint32 newValue);
     event MisdemeanorThresholdChanged(uint32 prevValue, uint32 newValue);
     event FelonyThresholdChanged(uint32 prevValue, uint32 newValue);
@@ -15,7 +15,7 @@ contract ChainConfig is InjectorContextHolder, IChainConfig {
     event MinStakingAmountChanged(uint256 prevValue, uint256 newValue);
 
     struct ConsensusParams {
-        uint32 activeValidatorsLength;
+        uint32 activeValidatorsLength; // depricated. use epochConsensusParams.activeValidatorLength
         uint32 epochBlockInterval;
         uint32 misdemeanorThreshold;
         uint32 felonyThreshold;
@@ -25,7 +25,19 @@ contract ChainConfig is InjectorContextHolder, IChainConfig {
         uint256 minStakingAmount;
     }
 
+    struct ActiveValidatorLength {
+        // (epoch => activeValidatorsLength)
+        mapping(uint64 => uint32) value;
+        // list of available epochs, sorted in asc order.
+        uint64[] epochs;
+    }
+
+    struct EpochConsensusParams {
+        ActiveValidatorLength activeValidatorLength;
+    }
+
     ConsensusParams private _consensusParams;
+    EpochConsensusParams private _epochConsensusParams;
 
     constructor(bytes memory constructorParams) InjectorContextHolder(constructorParams) {
     }
@@ -40,8 +52,9 @@ contract ChainConfig is InjectorContextHolder, IChainConfig {
         uint256 minValidatorStakeAmount,
         uint256 minStakingAmount
     ) external onlyInitializing {
-        _consensusParams.activeValidatorsLength = activeValidatorsLength;
-        emit ActiveValidatorsLengthChanged(0, activeValidatorsLength);
+        _epochConsensusParams.activeValidatorLength.value[0] = activeValidatorsLength;
+        _epochConsensusParams.activeValidatorLength.epochs.push(0);
+        emit ActiveValidatorsLengthChanged(0, activeValidatorsLength, 0);
         _consensusParams.epochBlockInterval = epochBlockInterval;
         emit EpochBlockIntervalChanged(0, epochBlockInterval);
         _consensusParams.misdemeanorThreshold = misdemeanorThreshold;
@@ -62,14 +75,64 @@ contract ChainConfig is InjectorContextHolder, IChainConfig {
         return _consensusParams;
     }
 
+    /// @notice depricated. use `getActiveValidatorsLength(uint64 epoch)` instead.
     function getActiveValidatorsLength() external view override returns (uint32) {
         return _consensusParams.activeValidatorsLength;
     }
 
+    function getActiveValidatorsLength(uint64 epoch) external view returns (uint32) {
+        ActiveValidatorLength storage avl = _epochConsensusParams.activeValidatorLength;
+
+        if (avl.value[epoch] > 0) {
+            return avl.value[epoch];
+        } else {
+            uint256 epochsLen = avl.epochs.length;
+            uint64 lastAvailableEpoch = avl.epochs[epochsLen - 1];
+            // If we don't have the value for the epoch, return the lastAvailable epoch value if possible.
+            // (actually, epoch == lastAvailableEpoch case should be covered by the if statement above, but whatever..)
+            if (epoch >= lastAvailableEpoch) {
+                return avl.value[lastAvailableEpoch];
+            } else {
+                // If we don't have the value for the epoch and epoch < lastAvailable
+                // binary search to find the closest epoch
+                uint256 left = 0;
+                uint256 right = epochsLen;
+                while (left < right) {
+                     uint256 mid = left + (right - left) / 2;
+                     if (avl.epochs[mid] <= epoch) {
+                         left = mid + 1;
+                     } else {
+                         right = mid;
+                     }
+                }
+                return avl.value[avl.epochs[left-1]];
+            }
+        }
+    }
+
+    function initActiveValidatorLengthEpochParam(uint64[] memory epochs, uint32[] memory lengths) public {
+        require(epochs.length == lengths.length, "IA"); // invalid arguments
+
+        ActiveValidatorLength storage avl = _epochConsensusParams.activeValidatorLength;
+        require(avl.epochs.length == 0, "AI"); // already initialized
+
+        uint256 len = epochs.length;
+        for (uint256 i = 0; i < len; i++) {
+            uint64 epoch = epochs[i];
+            avl.value[epoch] = lengths[i];
+            avl.epochs.push(epoch);
+        }
+    }
+
     function setActiveValidatorsLength(uint32 newValue) external override onlyFromGovernance {
-        uint32 prevValue = _consensusParams.activeValidatorsLength;
-        _consensusParams.activeValidatorsLength = newValue;
-        emit ActiveValidatorsLengthChanged(prevValue, newValue);
+        ActiveValidatorLength storage avl = _epochConsensusParams.activeValidatorLength;
+
+        // set new value for next epoch
+        uint64 nextEpoch = _stakingContract.nextEpoch();
+        uint32 prevValue = avl.value[avl.epochs[avl.epochs.length - 1]];
+        avl.value[nextEpoch] = newValue;
+        avl.epochs.push(nextEpoch);
+        emit ActiveValidatorsLengthChanged(prevValue, newValue, nextEpoch);
     }
 
     function getEpochBlockInterval() external view override returns (uint32) {

--- a/contracts/ChainConfig.sol
+++ b/contracts/ChainConfig.sol
@@ -25,7 +25,7 @@ contract ChainConfig is InjectorContextHolder, IChainConfig {
         uint256 minStakingAmount;
     }
 
-    struct Uint32Param {
+    struct EpochToValue {
         // (epoch => value)
         mapping(uint64 => uint32) value;
         // list of available epochs, sorted in asc order.
@@ -33,7 +33,7 @@ contract ChainConfig is InjectorContextHolder, IChainConfig {
     }
 
     struct EpochConsensusParams {
-        Uint32Param activeValidatorLength;
+        EpochToValue activeValidatorLength;
     }
 
     ConsensusParams private _consensusParams;
@@ -80,7 +80,7 @@ contract ChainConfig is InjectorContextHolder, IChainConfig {
     }
 
     function getActiveValidatorsLength(uint64 epoch) public view returns (uint32) {
-        Uint32Param storage avl = _epochConsensusParams.activeValidatorLength;
+        EpochToValue storage avl = _epochConsensusParams.activeValidatorLength;
 
         if (avl.value[epoch] > 0) {
             return avl.value[epoch];
@@ -112,7 +112,7 @@ contract ChainConfig is InjectorContextHolder, IChainConfig {
     function initActiveValidatorLengthEpochParam(uint64[] memory epochs, uint32[] memory lengths) public {
         require(epochs.length == lengths.length, "IA"); // invalid arguments
 
-        Uint32Param storage avl = _epochConsensusParams.activeValidatorLength;
+        EpochToValue storage avl = _epochConsensusParams.activeValidatorLength;
         require(avl.epochs.length == 0, "AI"); // already initialized
 
         uint256 len = epochs.length;
@@ -124,7 +124,7 @@ contract ChainConfig is InjectorContextHolder, IChainConfig {
     }
 
     function setActiveValidatorsLength(uint32 newValue) external override onlyFromGovernance {
-        Uint32Param storage avl = _epochConsensusParams.activeValidatorLength;
+        EpochToValue storage avl = _epochConsensusParams.activeValidatorLength;
 
         // set new value for next epoch
         uint64 nextEpoch = _stakingContract.nextEpoch();

--- a/contracts/ChainConfig.sol
+++ b/contracts/ChainConfig.sol
@@ -25,15 +25,15 @@ contract ChainConfig is InjectorContextHolder, IChainConfig {
         uint256 minStakingAmount;
     }
 
-    struct ActiveValidatorLength {
-        // (epoch => activeValidatorsLength)
+    struct Uint32Param {
+        // (epoch => value)
         mapping(uint64 => uint32) value;
         // list of available epochs, sorted in asc order.
         uint64[] epochs;
     }
 
     struct EpochConsensusParams {
-        ActiveValidatorLength activeValidatorLength;
+        Uint32Param activeValidatorLength;
     }
 
     ConsensusParams private _consensusParams;
@@ -81,7 +81,7 @@ contract ChainConfig is InjectorContextHolder, IChainConfig {
     }
 
     function getActiveValidatorsLength(uint64 epoch) external view returns (uint32) {
-        ActiveValidatorLength storage avl = _epochConsensusParams.activeValidatorLength;
+        Uint32Param storage avl = _epochConsensusParams.activeValidatorLength;
 
         if (avl.value[epoch] > 0) {
             return avl.value[epoch];
@@ -113,7 +113,7 @@ contract ChainConfig is InjectorContextHolder, IChainConfig {
     function initActiveValidatorLengthEpochParam(uint64[] memory epochs, uint32[] memory lengths) public {
         require(epochs.length == lengths.length, "IA"); // invalid arguments
 
-        ActiveValidatorLength storage avl = _epochConsensusParams.activeValidatorLength;
+        Uint32Param storage avl = _epochConsensusParams.activeValidatorLength;
         require(avl.epochs.length == 0, "AI"); // already initialized
 
         uint256 len = epochs.length;
@@ -125,7 +125,7 @@ contract ChainConfig is InjectorContextHolder, IChainConfig {
     }
 
     function setActiveValidatorsLength(uint32 newValue) external override onlyFromGovernance {
-        ActiveValidatorLength storage avl = _epochConsensusParams.activeValidatorLength;
+        Uint32Param storage avl = _epochConsensusParams.activeValidatorLength;
 
         // set new value for next epoch
         uint64 nextEpoch = _stakingContract.nextEpoch();

--- a/contracts/ChainConfig.sol
+++ b/contracts/ChainConfig.sol
@@ -75,12 +75,11 @@ contract ChainConfig is InjectorContextHolder, IChainConfig {
         return _consensusParams;
     }
 
-    /// @notice depricated. use `getActiveValidatorsLength(uint64 epoch)` instead.
     function getActiveValidatorsLength() external view override returns (uint32) {
-        return _consensusParams.activeValidatorsLength;
+        return getActiveValidatorsLength(_stakingContract.currentEpoch());
     }
 
-    function getActiveValidatorsLength(uint64 epoch) external view returns (uint32) {
+    function getActiveValidatorsLength(uint64 epoch) public view returns (uint32) {
         Uint32Param storage avl = _epochConsensusParams.activeValidatorLength;
 
         if (avl.value[epoch] > 0) {

--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -139,17 +139,14 @@ contract Governance is InjectorContextHolder, GovernorCountingSimpleUpgradeable,
 
     function _validatorVotingPowerAtEpoch(address validator, uint64 epoch) internal view returns (uint256) {
         // find validator votes at block number
-        (,uint8 status, uint256 totalDelegated,,,,,,) = _stakingContract.getValidatorStatusAtEpoch(validator, epoch);
-        // only active validators power makes sense
-        if (status != 0x01) {
-            return 0;
-        }
+        (,, uint256 totalDelegated,,,,,,) = _stakingContract.getValidatorStatusAtEpoch(validator, epoch);
         // use total delegated amount is a voting power
         return totalDelegated;
     }
 
     function _votingSupply(uint256 blockNumber) internal view returns (uint256 votingSupply) {
         uint64 epoch = uint64(blockNumber / _chainConfigContract.getEpochBlockInterval());
+        // Note: getValidatorsAtEpoch returns list of active main validators at epoch
         address[] memory validators = _stakingContract.getValidatorsAtEpoch(epoch);
         for (uint256 i = 0; i < validators.length; i++) {
             votingSupply += _validatorVotingPowerAtEpoch(validators[i], epoch);

--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -134,6 +134,11 @@ contract Governance is InjectorContextHolder, GovernorCountingSimpleUpgradeable,
     function _validatorVotingPowerAt(address validator, uint256 blockNumber) internal view returns (uint256) {
         // find validator votes at block number
         uint64 epoch = uint64(blockNumber / _chainConfigContract.getEpochBlockInterval());
+        return _validatorVotingPowerAtEpoch(validator, epoch);
+    }
+
+    function _validatorVotingPowerAtEpoch(address validator, uint64 epoch) internal view returns (uint256) {
+        // find validator votes at block number
         (,uint8 status, uint256 totalDelegated,,,,,,) = _stakingContract.getValidatorStatusAtEpoch(validator, epoch);
         // only active validators power makes sense
         if (status != 0x01) {
@@ -144,9 +149,10 @@ contract Governance is InjectorContextHolder, GovernorCountingSimpleUpgradeable,
     }
 
     function _votingSupply(uint256 blockNumber) internal view returns (uint256 votingSupply) {
-        address[] memory validators = _stakingContract.getValidators();
+        uint64 epoch = uint64(blockNumber / _chainConfigContract.getEpochBlockInterval());
+        address[] memory validators = _stakingContract.getValidatorsAtEpoch(epoch);
         for (uint256 i = 0; i < validators.length; i++) {
-            votingSupply += _validatorVotingPowerAt(validators[i], blockNumber);
+            votingSupply += _validatorVotingPowerAtEpoch(validators[i], epoch);
         }
         return votingSupply;
     }

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -714,10 +714,11 @@ contract Staking is IStaking, InjectorContextHolder {
     }
 
     function _getValidators(uint64 epoch) internal view returns (address[] memory) {
-        uint256 n = _activeValidatorsList.length;
+        address[] memory avl = getActiveValidatorsList(epoch);
+        uint256 n = avl.length;
         address[] memory orderedValidators = new address[](n);
         for (uint256 i = 0; i < n; i++) {
-            orderedValidators[i] = _activeValidatorsList[i];
+            orderedValidators[i] = avl[i];
         }
         // we need to select k top validators out of n
         uint256 k = _chainConfigContract.getActiveValidatorsLength(epoch);

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -216,9 +216,9 @@ contract Staking is IStaking, InjectorContextHolder {
         emit ValidatorReleased(validatorAddress, _currentEpoch());
     }
 
-    function _totalDelegatedToValidator(Validator memory validator) internal view returns (uint256) {
-        ValidatorSnapshot memory snapshot = _validatorSnapshots[validator.validatorAddress][validator.changedAt];
-        return _unpackCompact(snapshot.totalDelegated);
+    function _totalDelegatedToValidator(Validator memory validator, uint64 epoch) internal view returns (uint256) {
+        ValidatorSnapshot memory s = _fetchValidatorSnapshot(validator, epoch);
+        return _unpackCompact(s.totalDelegated);
     }
 
     function delegate(address validatorAddress) payable external override {
@@ -665,7 +665,7 @@ contract Staking is IStaking, InjectorContextHolder {
             orderedValidators[i] = _activeValidatorsList[i];
         }
         // we need to select k top validators out of n
-        uint256 k = _chainConfigContract.getActiveValidatorsLength();
+        uint256 k = _chainConfigContract.getActiveValidatorsLength(); // TODO: SHOULD THIS BE PER EPOCH?
         if (k > n) {
             k = n;
         }
@@ -674,7 +674,7 @@ contract Staking is IStaking, InjectorContextHolder {
             Validator memory currentMax = _validatorsMap[orderedValidators[nextValidator]];
             for (uint256 j = i + 1; j < n; j++) {
                 Validator memory current = _validatorsMap[orderedValidators[j]];
-                if (_totalDelegatedToValidator(currentMax) < _totalDelegatedToValidator(current)) {
+                if (_totalDelegatedToValidator(currentMax, epoch) < _totalDelegatedToValidator(current, epoch)) {
                     nextValidator = j;
                     currentMax = current;
                 }

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -665,7 +665,7 @@ contract Staking is IStaking, InjectorContextHolder {
             orderedValidators[i] = _activeValidatorsList[i];
         }
         // we need to select k top validators out of n
-        uint256 k = _chainConfigContract.getActiveValidatorsLength(); // TODO: SHOULD THIS BE PER EPOCH?
+        uint256 k = _chainConfigContract.getActiveValidatorsLength(epoch);
         if (k > n) {
             k = n;
         }

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -646,7 +646,7 @@ contract Staking is IStaking, InjectorContextHolder {
     function _activateValidator(address validatorAddress) internal {
         Validator memory validator = _validatorsMap[validatorAddress];
         require(_validatorsMap[validatorAddress].status == ValidatorStatus.Pending, "np"); // not pending
-        _activeValidatorsList.push(validatorAddress);
+        _addValidatorToActiveValidatorsList(validatorAddress, _nextEpoch());
         validator.status = ValidatorStatus.Active;
         ValidatorSnapshot storage snapshot = _touchValidatorSnapshot(validator, _nextEpoch());
         _validatorsMap[validatorAddress] = validator;

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -651,6 +651,14 @@ contract Staking is IStaking, InjectorContextHolder {
     }
 
     function getValidators() public view override returns (address[] memory) {
+        return _getValidators(_currentEpoch());
+    }
+
+    function getValidatorsAtEpoch(uint64 epoch) public view returns (address[] memory) {
+        return _getValidators(epoch);
+    }
+
+    function _getValidators(uint64 epoch) internal view returns (address[] memory) {
         uint256 n = _activeValidatorsList.length;
         address[] memory orderedValidators = new address[](n);
         for (uint256 i = 0; i < n; i++) {

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -220,7 +220,7 @@ contract Staking is IStaking, InjectorContextHolder {
         // update validator status
         validator.status = ValidatorStatus.Active;
         _validatorsMap[validatorAddress] = validator;
-        _activeValidatorsList.push(validatorAddress);
+        _addValidatorToActiveValidatorsList(validatorAddress, _nextEpoch());
         // emit event
         emit ValidatorReleased(validatorAddress, _currentEpoch());
     }

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -609,19 +609,21 @@ contract Staking is IStaking, InjectorContextHolder {
     }
 
     function _removeValidatorFromActiveList(address validatorAddress) internal {
-        // find index of validator in validator set
-        int256 indexOf = - 1;
-        for (uint256 i = 0; i < _activeValidatorsList.length; i++) {
-            if (_activeValidatorsList[i] != validatorAddress) continue;
-            indexOf = int256(i);
-            break;
+        // if the list doesn't exist for next epoch, copy over the last known list
+        uint64 ne = _nextEpoch();
+        if (_activeValidatorsListPerEpoch.value[ne].length == 0) {
+            uint64 lastKnownEpoch = _activeValidatorsListPerEpoch.epochs[_activeValidatorsListPerEpoch.epochs.length - 1];
+            _activeValidatorsListPerEpoch.value[ne] = _activeValidatorsListPerEpoch.value[lastKnownEpoch];
+            _activeValidatorsListPerEpoch.epochs.push(ne);
         }
+
         // remove validator from array (since we remove only active it might not exist in the list)
-        if (indexOf >= 0) {
-            if (_activeValidatorsList.length > 1 && uint256(indexOf) != _activeValidatorsList.length - 1) {
-                _activeValidatorsList[uint256(indexOf)] = _activeValidatorsList[_activeValidatorsList.length - 1];
-            }
-            _activeValidatorsList.pop();
+        address[] storage avl = _activeValidatorsListPerEpoch.value[ne];
+        for (uint256 i = 0; i < avl.length; i++) {
+            if (avl[i] != validatorAddress) continue;
+            avl[i] = avl[avl.length - 1];
+            avl.pop();
+            return;
         }
     }
 

--- a/contracts/interfaces/IChainConfig.sol
+++ b/contracts/interfaces/IChainConfig.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 interface IChainConfig {
 
     function getActiveValidatorsLength() external view returns (uint32);
+    function getActiveValidatorsLength(uint64 epoch) external view returns (uint32);
 
     function setActiveValidatorsLength(uint32 newValue) external;
 

--- a/contracts/interfaces/IStaking.sol
+++ b/contracts/interfaces/IStaking.sol
@@ -13,6 +13,8 @@ interface IStaking is IValidatorSet {
 
     function isValidator(address validator) external view returns (bool);
 
+    function getValidatorsAtEpoch(uint64 epoch) external view returns (address[] memory);
+
     function getValidatorStatus(address validator) external view returns (
         address ownerAddress,
         uint8 status,
@@ -75,7 +77,7 @@ interface IStaking is IValidatorSet {
     function claimValidatorFeeAtEpoch(address validator, uint64 beforeEpoch) external;
 
     function getDelegatorFee(address validator, address delegator) external view returns (uint256);
-    
+
     function getDelegatorFeeAtEpoch(address validator, address delegator, uint64) external view returns (uint256);
 
     function getPendingDelegatorFee(address validator, address delegator) external view returns (uint256);

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,14 @@
+[profile.default]
+src = "contracts"
+out = "out"
+script = "scripts"
+libs = ["node_modules", "lib"]
+remappings = [
+    "@openzeppelin/=node_modules/@openzeppelin/",
+    "eth-gas-reporter/=node_modules/eth-gas-reporter/",
+    "truffle/=node_modules/truffle/",
+    "forge-std/=lib/forge-std/src/",
+]
+# gas_limit = "18446744073709551615"
+
+# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/scripts/Benchmark.s.sol
+++ b/scripts/Benchmark.s.sol
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script, console} from "forge-std/Script.sol";
+
+import "../contracts/interfaces/IChainConfig.sol";
+import "../contracts/interfaces/IGovernance.sol";
+import "../contracts/interfaces/ISlashingIndicator.sol";
+import "../contracts/interfaces/ISystemReward.sol";
+import "../contracts/interfaces/IRuntimeUpgradeEvmHook.sol";
+import "../contracts/interfaces/IValidatorSet.sol";
+import "../contracts/interfaces/IStaking.sol";
+import "../contracts/interfaces/IRuntimeUpgrade.sol";
+import "../contracts/interfaces/IStakingPool.sol";
+import "../contracts/interfaces/IInjector.sol";
+import "../contracts/interfaces/IDeployerProxy.sol";
+import "../contracts/interfaces/ITokenomics.sol";
+
+import {Staking} from "../contracts/Staking.sol";
+import {ChainConfig} from "../contracts/ChainConfig.sol";
+
+contract BenchmarkScriptEnv is Script {
+    Staking internal staking;
+    ChainConfig internal chainConfig;
+
+    uint16 internal constant EPOCH_LEN = 100;
+    uint256 internal constant MAX_GAS = 24_000_000;
+
+
+    function setUp() public {
+        bytes memory ctorChainConfig = abi.encodeWithSignature(
+            "ctor(uint32,uint32,uint32,uint32,uint32,uint32,uint256,uint256)",
+            type(uint32).max, // number of main validators
+            EPOCH_LEN, // epoch len
+            50, // misdemeanorThreshold
+            75, // felonyThreshold
+            1, // validatorJailEpochLength
+            1, // undelegatePeriod
+            0, // minValidatorStakeAmount
+            0 // minStakingAmount
+        );
+        chainConfig = new ChainConfig(ctorChainConfig);
+
+        address[] memory valAddrArray = new address[](1);
+        valAddrArray[0] = vm.addr(1);
+        uint256[] memory initialStakeArray = new uint256[](1);
+        bytes memory ctoStaking = abi.encodeWithSignature("ctor(address[],uint256[],uint16)", valAddrArray, initialStakeArray, 0);
+        staking = new Staking(ctoStaking);
+
+        IStaking stakingContract = IStaking(staking);
+        ISlashingIndicator slashingIndicatorContract = ISlashingIndicator(vm.addr(20));
+        ISystemReward systemRewardContract = ISystemReward(vm.addr(20));
+        IStakingPool stakingPoolContract = IStakingPool(vm.addr(20));
+        IGovernance governanceContract = IGovernance(vm.addr(20));
+        IChainConfig chainConfigContract = IChainConfig(chainConfig);
+        IRuntimeUpgrade runtimeUpgradeContract = IRuntimeUpgrade(vm.addr(20));
+        IDeployerProxy deployerProxyContract = IDeployerProxy(vm.addr(20));
+        ITokenomics tokenomicsContract = ITokenomics(vm.addr(20));
+
+        chainConfig.initManually(
+            stakingContract,
+            slashingIndicatorContract,
+            systemRewardContract,
+            stakingPoolContract,
+            governanceContract,
+            chainConfigContract,
+            runtimeUpgradeContract,
+            deployerProxyContract,
+            tokenomicsContract
+        );
+
+        staking.initManually(
+            stakingContract,
+            slashingIndicatorContract,
+            systemRewardContract,
+            stakingPoolContract,
+            governanceContract,
+            chainConfigContract,
+            runtimeUpgradeContract,
+            deployerProxyContract,
+            tokenomicsContract
+        );
+    }
+}
+
+contract AddValidatorBenchmarkScript is BenchmarkScriptEnv {
+    function run() public {
+        // keep adding validators until addValidator exceeds block gas limit
+        uint256 counter = 2;
+        uint256 addValidatorGas = 0;
+        uint256 firstCallGas = 0;
+        uint256 lastUsage = 0;
+        vm.startPrank(vm.addr(20));
+        while(addValidatorGas < MAX_GAS){
+            lastUsage = addValidatorGas;
+            addValidatorGas = addValidatorGasUsage(vm.addr(counter));
+            if (counter == 2) {
+                firstCallGas = addValidatorGas;
+            }
+            counter++;
+            vm.roll(block.number + EPOCH_LEN);
+        }
+        vm.stopPrank();
+
+        console.log("addValidator");
+        console.log("Number of validators: ", --counter);
+        console.log("First Call Gas: ", firstCallGas);
+        console.log("Total Gas: ", lastUsage);
+        console.log("====");
+    }
+
+    function addValidatorGasUsage(address newValidator) internal returns (uint256 gasUsed) {
+        vm.startSnapshotGas("addValidatorGasUsage");
+        staking.addValidator(newValidator);
+        gasUsed = vm.stopSnapshotGas();
+    }
+}
+
+contract GetValidatorsPerEpochBenchmarkScript is BenchmarkScriptEnv {
+    function run() public {
+        // keep adding validators until getValidators exceeds block gas limit
+        uint64 nextEpoch = staking.nextEpoch();
+        uint256 getValidatorsGas = getValidatorsGasUsage(nextEpoch);
+        uint256 counter = 2;
+        uint256 firstCallGas = 0;
+        uint256 lastUsage = 0;
+        vm.startPrank(vm.addr(20));
+        while(getValidatorsGas < MAX_GAS){
+            staking.addValidator(vm.addr(counter));
+            lastUsage = getValidatorsGas;
+            getValidatorsGas = getValidatorsGasUsage(nextEpoch);
+            if (counter == 2) {
+                firstCallGas = getValidatorsGas;
+            }
+            counter++;
+        }
+        vm.stopPrank();
+
+        console.log("getValidators");
+        console.log("Number of validators: ", counter--);
+        console.log("First Call Gas: ", firstCallGas);
+        console.log("Total Gas: ", lastUsage);
+        console.log("====");
+    }
+
+    function getValidatorsGasUsage(uint64 epoch) internal returns (uint256 gasUsed) {
+        vm.startSnapshotGas("getValidatorsGasUsage");
+        staking.getValidatorsAtEpoch(epoch);
+        gasUsed = vm.stopSnapshotGas();
+    }
+}
+
+contract GetValidatorsBenchmarkScript is BenchmarkScriptEnv {
+    function run() public {
+        // keep adding validators until getValidators exceeds block gas limit
+        uint256 getValidatorsGas = getValidatorsGasUsage();
+        uint256 counter = 2;
+        uint256 firstCallGas = 0;
+        uint256 lastUsage = 0;
+        vm.startPrank(vm.addr(20));
+        while(getValidatorsGas < MAX_GAS){
+            staking.addValidator(vm.addr(counter));
+            lastUsage = getValidatorsGas;
+            getValidatorsGas = getValidatorsGasUsage();
+            if (counter == 2) {
+                firstCallGas = getValidatorsGas;
+            }
+            counter++;
+        }
+        vm.stopPrank();
+
+        console.log("getValidators");
+        console.log("Number of validators: ", --counter);
+        console.log("First Call Gas: ", firstCallGas);
+        console.log("Total Gas: ", lastUsage);
+        console.log("====");
+    }
+
+    function getValidatorsGasUsage() internal returns (uint256 gasUsed) {
+        vm.startSnapshotGas("getValidatorsGasUsage");
+        staking.getValidators();
+        gasUsed = vm.stopSnapshotGas();
+    }
+}
+
+contract RemoveValidatorBenchmarkScript is BenchmarkScriptEnv {
+    // add validator
+    // go to next epoch
+    // remove the validator (at last index)
+    function run() public {
+        // keep adding validators until removeValidator exceeds block gas limit
+        uint256 removeValidatorGas;
+        uint256 counter = 2;
+        uint256 firstCallGas = 0;
+        uint256 lastUsage = 0;
+        vm.startPrank(vm.addr(20));
+        while(removeValidatorGas < MAX_GAS) {
+            // adds validators in next epoch
+            for (uint256 i = counter; i <= counter * 2; i++) {
+                staking.addValidator(vm.addr(i));
+            }
+
+            vm.roll(block.number + EPOCH_LEN);
+
+            // removes validator in next epoch
+            // validator with addreee = vm.addr(counter), will be at the end of validators list
+            // that will be the worst case scenario
+            lastUsage = removeValidatorGas;
+            removeValidatorGas = removeValidatorGasUsage(vm.addr(counter * 2));
+            if (counter == 2) {
+                firstCallGas = removeValidatorGas;
+            }
+            counter = counter * 2 + 1;
+        }
+        vm.stopPrank();
+
+        console.log("removeValidator");
+        console.log("Number of validators: ", (counter - 1) / 2);
+        console.log("First Call Gas: ", firstCallGas);
+        console.log("Total Gas: ", lastUsage);
+        console.log("====");
+    }
+
+    function removeValidatorGasUsage(address validator) internal returns (uint256 gasUsed) {
+        vm.startSnapshotGas("removeValidatorGasUsage");
+        staking.removeValidator(validator);
+        gasUsed = vm.stopSnapshotGas();
+    }
+}

--- a/test/Governance-Sherlock66.t.sol
+++ b/test/Governance-Sherlock66.t.sol
@@ -110,7 +110,7 @@ contract GovernanceSherlock66 is Test {
         uint256 initialQuorum = (90e18) * 2/3;
         assertEq(governance.quorum(block.number), initialQuorum);
 
-        staking.delegate{value: 50 ether}(vm.addr(8));
+        staking.delegate{value: 40 ether}(vm.addr(8));
 
         vm.roll(block.number + EPOCH_LEN);
 

--- a/test/Governance-Sherlock66.t.sol
+++ b/test/Governance-Sherlock66.t.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test, console} from "forge-std/Test.sol";
+
+import "../contracts/interfaces/IChainConfig.sol";
+import "../contracts/interfaces/IGovernance.sol";
+import "../contracts/interfaces/ISlashingIndicator.sol";
+import "../contracts/interfaces/ISystemReward.sol";
+import "../contracts/interfaces/IRuntimeUpgradeEvmHook.sol";
+import "../contracts/interfaces/IValidatorSet.sol";
+import "../contracts/interfaces/IStaking.sol";
+import "../contracts/interfaces/IRuntimeUpgrade.sol";
+import "../contracts/interfaces/IStakingPool.sol";
+import "../contracts/interfaces/IInjector.sol";
+import "../contracts/interfaces/IDeployerProxy.sol";
+import "../contracts/interfaces/ITokenomics.sol";
+
+import {StakingPool} from "../contracts/StakingPool.sol";
+import {Staking} from "../contracts/Staking.sol";
+import {Governance} from "../contracts/Governance.sol";
+import {ChainConfig} from "../contracts/ChainConfig.sol";
+
+contract GovernanceSherlock66 is Test {
+    Staking public staking;
+    Governance public governance;
+
+    uint16 public constant EPOCH_LEN = 100;
+
+    function setUp() public {
+        bytes memory ctorChainConfig = abi.encodeWithSignature(
+            "ctor(uint32,uint32,uint32,uint32,uint32,uint32,uint256,uint256)",
+            3, // number of main validators
+            EPOCH_LEN, // epoch len
+            50, // misdemeanorThreshold
+            75, // felonyThreshold
+            1, // validatorJailEpochLength
+            1, // undelegatePeriod
+            0, // minValidatorStakeAmount
+            0 // minStakingAmount
+        );
+        ChainConfig chainConfig = new ChainConfig(ctorChainConfig);
+
+        address[] memory valAddrArray = new address[](4);
+        valAddrArray[0] = vm.addr(5);
+        valAddrArray[1] = vm.addr(6);
+        valAddrArray[2] = vm.addr(7);
+        valAddrArray[3] = vm.addr(8);
+        uint256[] memory initialStakeArray = new uint256[](4);
+        initialStakeArray[0] = 40 ether;
+        initialStakeArray[1] = 30 ether;
+        initialStakeArray[2] = 20 ether;
+        initialStakeArray[3] = 10 ether;
+
+        bytes memory ctoStaking = abi.encodeWithSignature("ctor(address[],uint256[],uint16)", valAddrArray, initialStakeArray, 0);
+        staking = new Staking(ctoStaking);
+
+        bytes memory ctorGovernance = abi.encodeWithSignature("ctor(uint256)", EPOCH_LEN);
+        governance = new Governance(ctorGovernance);
+
+        IStaking stakingContract = IStaking(staking);
+        ISlashingIndicator slashingIndicatorContract = ISlashingIndicator(vm.addr(20));
+        ISystemReward systemRewardContract = ISystemReward(vm.addr(20));
+        IStakingPool stakingPoolContract = IStakingPool(vm.addr(20));
+        IGovernance governanceContract = IGovernance(governance);
+        IChainConfig chainConfigContract = IChainConfig(chainConfig);
+        IRuntimeUpgrade runtimeUpgradeContract = IRuntimeUpgrade(vm.addr(20));
+        IDeployerProxy deployerProxyContract = IDeployerProxy(vm.addr(20));
+        ITokenomics tokenomicsContract = ITokenomics(vm.addr(20));
+
+        chainConfig.initManually(
+            stakingContract,
+            slashingIndicatorContract,
+            systemRewardContract,
+            stakingPoolContract,
+            governanceContract,
+            chainConfigContract,
+            runtimeUpgradeContract,
+            deployerProxyContract,
+            tokenomicsContract
+        );
+
+        vm.deal(address(staking), 100 ether);
+        staking.initManually(
+            stakingContract,
+            slashingIndicatorContract,
+            systemRewardContract,
+            stakingPoolContract,
+            governanceContract,
+            chainConfigContract,
+            runtimeUpgradeContract,
+            deployerProxyContract,
+            tokenomicsContract
+        );
+
+        governance.initManually(
+            stakingContract,
+            slashingIndicatorContract,
+            systemRewardContract,
+            stakingPoolContract,
+            governanceContract,
+            chainConfigContract,
+            runtimeUpgradeContract,
+            deployerProxyContract,
+            tokenomicsContract
+        );
+    }
+
+    function test_quorum() public {
+        uint256 initialQuorum = (90e18) * 2/3;
+        assertEq(governance.quorum(block.number), initialQuorum);
+
+        staking.delegate{value: 50 ether}(vm.addr(8));
+
+        vm.roll(block.number + EPOCH_LEN);
+
+        uint256 newQuorum = (120e18) * 2/3;
+
+        assertEq(governance.quorum(block.number - EPOCH_LEN), initialQuorum);
+        assertEq(governance.quorum(block.number), newQuorum);
+    }
+}

--- a/test/Staking-Sherlock66.t.sol
+++ b/test/Staking-Sherlock66.t.sol
@@ -172,4 +172,41 @@ contract StakingSherlock66 is Test {
         assertEq(avl[3], val4);
         assertEq(avl[4], val5);
     }
+
+    function test_slash() public {
+        address val1 = vm.addr(1);
+        address val2 = vm.addr(2);
+        address val3 = vm.addr(3);
+        address val4 = vm.addr(4);
+        vm.startPrank(vm.addr(20));
+        staking.addValidator(val2);
+        staking.addValidator(val3);
+        staking.addValidator(val4);
+        vm.stopPrank();
+
+        // go to epoch 1 & jail one validator
+        vm.roll(block.number + EPOCH_LEN);
+        for (uint8 i = 0; i < 74; i++) {
+            vm.prank(vm.addr(20));
+            staking.slash(val3);
+        }
+        // slash again to jail it
+        vm.prank(vm.addr(20));
+        staking.slash(val3);
+
+        // at epoch 1 we should have 4 validators
+        address[] memory avl = staking.getActiveValidatorsList(1);
+        assertEq(avl.length, 4);
+        assertEq(avl[0], val1);
+        assertEq(avl[1], val2);
+        assertEq(avl[2], val3);
+        assertEq(avl[3], val4);
+
+        // at epoch 2 we should have 3 validators
+        avl = staking.getActiveValidatorsList(2);
+        assertEq(avl.length, 3);
+        assertEq(avl[0], val1);
+        assertEq(avl[1], val2);
+        assertEq(avl[2], val4);
+    }
 }

--- a/test/Staking-Sherlock66.t.sol
+++ b/test/Staking-Sherlock66.t.sol
@@ -122,10 +122,7 @@ contract StakingSherlock66 is Test {
         vm.roll(block.number + EPOCH_LEN);
 
         vm.prank(vm.addr(20));
-        vm.startSnapshotGas("A");
         staking.removeValidator(val3);
-        uint256 gasUsed = vm.stopSnapshotGas();
-        console.log("gasUsed: ", gasUsed);
 
         // at epoch 1 we should have 4 validators
         address[] memory avl = staking.getActiveValidatorsList(1);
@@ -141,5 +138,38 @@ contract StakingSherlock66 is Test {
         assertEq(avl[0], val1);
         assertEq(avl[1], val2);
         assertEq(avl[2], val4);
+    }
+
+    function test_activateValidator() public {
+        address val1 = vm.addr(1);
+        address val2 = vm.addr(2);
+        address val3 = vm.addr(3);
+        address val4 = vm.addr(4);
+        vm.startPrank(vm.addr(20));
+        staking.addValidator(val2);
+        staking.addValidator(val3);
+        staking.addValidator(val4);
+        vm.stopPrank();
+
+        address val5 = vm.addr(5);
+        vm.prank(vm.addr(20));
+        staking.registerValidator(val5, 0);
+
+        vm.prank(vm.addr(20));
+        staking.activateValidator(val5);
+
+        // at epoch 0 we should only have 1 validator
+        address[] memory avl = staking.getActiveValidatorsList(0);
+        assertEq(avl.length, 1);
+        assertEq(avl[0], val1);
+
+        // at epoch 1 we should have 5 validators
+        avl = staking.getActiveValidatorsList(1);
+        assertEq(avl.length, 5);
+        assertEq(avl[0], val1);
+        assertEq(avl[1], val2);
+        assertEq(avl[2], val3);
+        assertEq(avl[3], val4);
+        assertEq(avl[4], val5);
     }
 }

--- a/test/Staking-Sherlock66.t.sol
+++ b/test/Staking-Sherlock66.t.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test, console} from "forge-std/Test.sol";
+
+import "../contracts/interfaces/IChainConfig.sol";
+import "../contracts/interfaces/IGovernance.sol";
+import "../contracts/interfaces/ISlashingIndicator.sol";
+import "../contracts/interfaces/ISystemReward.sol";
+import "../contracts/interfaces/IRuntimeUpgradeEvmHook.sol";
+import "../contracts/interfaces/IValidatorSet.sol";
+import "../contracts/interfaces/IStaking.sol";
+import "../contracts/interfaces/IRuntimeUpgrade.sol";
+import "../contracts/interfaces/IStakingPool.sol";
+import "../contracts/interfaces/IInjector.sol";
+import "../contracts/interfaces/IDeployerProxy.sol";
+import "../contracts/interfaces/ITokenomics.sol";
+
+import {Staking} from "../contracts/Staking.sol";
+import {ChainConfig} from "../contracts/ChainConfig.sol";
+
+contract StakingSherlock66 is Test {
+    Staking public staking;
+    ChainConfig public chainConfig;
+
+    uint16 public constant EPOCH_LEN = 100;
+
+    function setUp() public {
+        bytes memory ctorChainConfig = abi.encodeWithSignature(
+            "ctor(uint32,uint32,uint32,uint32,uint32,uint32,uint256,uint256)",
+            5, // number of main validators
+            EPOCH_LEN, // epoch len
+            50, // misdemeanorThreshold
+            75, // felonyThreshold
+            1, // validatorJailEpochLength
+            1, // undelegatePeriod
+            0, // minValidatorStakeAmount
+            0 // minStakingAmount
+        );
+        chainConfig = new ChainConfig(ctorChainConfig);
+
+        address[] memory valAddrArray = new address[](1);
+        valAddrArray[0] = vm.addr(1);
+        uint256[] memory initialStakeArray = new uint256[](1);
+
+        bytes memory ctoStaking = abi.encodeWithSignature("ctor(address[],uint256[],uint16)", valAddrArray, initialStakeArray, 0);
+        staking = new Staking(ctoStaking);
+
+        IStaking stakingContract = IStaking(staking);
+        ISlashingIndicator slashingIndicatorContract = ISlashingIndicator(vm.addr(20));
+        ISystemReward systemRewardContract = ISystemReward(vm.addr(20));
+        IStakingPool stakingPoolContract = IStakingPool(vm.addr(20));
+        IGovernance governanceContract = IGovernance(vm.addr(20));
+        IChainConfig chainConfigContract = IChainConfig(chainConfig);
+        IRuntimeUpgrade runtimeUpgradeContract = IRuntimeUpgrade(vm.addr(20));
+        IDeployerProxy deployerProxyContract = IDeployerProxy(vm.addr(20));
+        ITokenomics tokenomicsContract = ITokenomics(vm.addr(20));
+
+        chainConfig.initManually(
+            stakingContract,
+            slashingIndicatorContract,
+            systemRewardContract,
+            stakingPoolContract,
+            governanceContract,
+            chainConfigContract,
+            runtimeUpgradeContract,
+            deployerProxyContract,
+            tokenomicsContract
+        );
+
+        staking.initManually(
+            stakingContract,
+            slashingIndicatorContract,
+            systemRewardContract,
+            stakingPoolContract,
+            governanceContract,
+            chainConfigContract,
+            runtimeUpgradeContract,
+            deployerProxyContract,
+            tokenomicsContract
+        );
+    }
+
+    function test_addValidator() public {
+        address val1 = vm.addr(1);
+
+        address val2 = vm.addr(2);
+        address val3 = vm.addr(3);
+        address val4 = vm.addr(4);
+        vm.startPrank(vm.addr(20));
+        staking.addValidator(val2);
+        staking.addValidator(val3);
+        staking.addValidator(val4);
+        vm.stopPrank();
+
+        // at epoch 0 we should only have 1 validator
+        address[] memory avl = staking.getActiveValidatorsList(0);
+        assertEq(avl.length, 1);
+        assertEq(avl[0], val1);
+
+        // at epoch 1 we should have 4 validators
+        avl = staking.getActiveValidatorsList(1);
+        assertEq(avl.length, 4);
+        assertEq(avl[0], val1);
+        assertEq(avl[1], val2);
+        assertEq(avl[2], val3);
+        assertEq(avl[3], val4);
+    }
+}

--- a/test/Staking-Sherlock66.t.sol
+++ b/test/Staking-Sherlock66.t.sol
@@ -209,4 +209,51 @@ contract StakingSherlock66 is Test {
         assertEq(avl[1], val2);
         assertEq(avl[2], val4);
     }
+
+    function test_releaseValidatorFromJail() public {
+        address val1 = vm.addr(1);
+        address val2 = vm.addr(2);
+        address val3 = vm.addr(3);
+        address val4 = vm.addr(4);
+        vm.startPrank(vm.addr(20));
+        staking.addValidator(val2);
+        staking.addValidator(val3);
+        staking.addValidator(val4);
+        vm.stopPrank();
+
+        // go to epoch 1 & jail one validator
+        vm.roll(block.number + EPOCH_LEN);
+        for (uint8 i = 0; i < 75; i++) {
+            vm.prank(vm.addr(20));
+            staking.slash(val3);
+        }
+
+        // go to epoch 2 & release it
+        vm.roll(block.number + EPOCH_LEN);
+        vm.prank(val3);
+        staking.releaseValidatorFromJail(val3);
+
+        // at epoch 1 we should have 4 validators
+        address[] memory avl = staking.getActiveValidatorsList(1);
+        assertEq(avl.length, 4);
+        assertEq(avl[0], val1);
+        assertEq(avl[1], val2);
+        assertEq(avl[2], val3);
+        assertEq(avl[3], val4);
+
+        // at epoch 2 we should have 3 validators
+        avl = staking.getActiveValidatorsList(2);
+        assertEq(avl.length, 3);
+        assertEq(avl[0], val1);
+        assertEq(avl[1], val2);
+        assertEq(avl[2], val4);
+
+        // at epoch 3 we should have 4 validators again
+        avl = staking.getActiveValidatorsList(3);
+        assertEq(avl.length, 4);
+        assertEq(avl[0], val1);
+        assertEq(avl[1], val2);
+        assertEq(avl[2], val4);
+        assertEq(avl[3], val3);
+    }
 }

--- a/test/Staking-Sherlock66.t.sol
+++ b/test/Staking-Sherlock66.t.sol
@@ -106,4 +106,40 @@ contract StakingSherlock66 is Test {
         assertEq(avl[2], val3);
         assertEq(avl[3], val4);
     }
+
+    function test_removeValidator() public {
+        address val1 = vm.addr(1);
+        address val2 = vm.addr(2);
+        address val3 = vm.addr(3);
+        address val4 = vm.addr(4);
+        vm.startPrank(vm.addr(20));
+        staking.addValidator(val2);
+        staking.addValidator(val3);
+        staking.addValidator(val4);
+        vm.stopPrank();
+
+        // go to epoch 1 & remove one validator
+        vm.roll(block.number + EPOCH_LEN);
+
+        vm.prank(vm.addr(20));
+        vm.startSnapshotGas("A");
+        staking.removeValidator(val3);
+        uint256 gasUsed = vm.stopSnapshotGas();
+        console.log("gasUsed: ", gasUsed);
+
+        // at epoch 1 we should have 4 validators
+        address[] memory avl = staking.getActiveValidatorsList(1);
+        assertEq(avl.length, 4);
+        assertEq(avl[0], val1);
+        assertEq(avl[1], val2);
+        assertEq(avl[2], val3);
+        assertEq(avl[3], val4);
+
+        // at epoch 2 we should have 3 validators
+        avl = staking.getActiveValidatorsList(2);
+        assertEq(avl.length, 3);
+        assertEq(avl[0], val1);
+        assertEq(avl[1], val2);
+        assertEq(avl[2], val4);
+    }
 }


### PR DESCRIPTION
# Problem
If we start with the `quorum()` function and follow the calls, we'll see that it calls `_votingSupply()` function with the `blockNumber` argument, which is not used
when calling `getValidators()`. Therefore the `_votingSupply()` function always gets the latest list of active main validators, leading to incorrect quorum calculation
for past block numbers.

# Solution
To fix the issue I added a `getValidatorsAtEpoch()` function to `Staking.sol` that receives the epoch as an argument and returns the list of active main validators at that epoch.
To make `getValidatorsAtEpoch()` work, I had to:
1. Store `activeValidatorsLength` values per epoch in `ChainConfig`.
2. Store `activeValidatorsList` per epoch in `Staking`.
3. Update `_totalDelegatedToValidator()`, add the epoch argument, so that it returned the total delegated amount at that epoch instead of the latest one.
4. Remove validator status check in `_validatorVotingPowerAtEpoch()` function in `Governance`.

## Storing active validators length per epoch
To achieve this I added two new structs to `ChainConfig.sol`:
```diff
+    struct EpochToValue {
+        // (epoch => value)
+        mapping(uint64 => uint32) value;
+        // list of available epochs, sorted in asc order.
+        uint64[] epochs;
+    }

+    struct EpochConsensusParams {
+        EpochToValue activeValidatorLength;
+    }
```

- `EpochConsensusParams` struct is a 'container' for consensus parameters that need to be tracked on per-epoch basis.
- `EpochToValue` struct allows saving the active validators length value per epoch and is optimized for fast reading.

The data can be accessed using the new `getActiveValidatorsLength` function:
```diff
+    function getActiveValidatorsLength(uint64 epoch) external view returns (uint32) {
+        EpochToValue storage avl = _epochConsensusParams.activeValidatorLength;
+
+        if (avl.value[epoch] > 0) {
+            return avl.value[epoch];
+        } else {
+            uint256 epochsLen = avl.epochs.length;
+            uint64 lastAvailableEpoch = avl.epochs[epochsLen - 1];
+            // If we don't have the value for the epoch, return the lastAvailable epoch value if possible.
+            // (actually, epoch == lastAvailableEpoch case should be covered by the if statement above, but whatever..)
+            if (epoch >= lastAvailableEpoch) {
+                return avl.value[lastAvailableEpoch];
+            } else {
+                // If we don't have the value for the epoch and epoch < lastAvailable
+                // binary search to find the closest epoch
+                uint256 left = 0;
+                uint256 right = epochsLen;
+                while (left < right) {
+                     uint256 mid = left + (right - left) / 2;
+                     if (avl.epochs[mid] <= epoch) {
+                         left = mid + 1;
+                     } else {
+                         right = mid;
+                     }
+                }
+                return avl.value[avl.epochs[left-1]];
+            }
+        }
+    }
```

## Storing `activeValidatorsList` per epoch
For now, I used a similar approach to store the active validators list per epoch in Staking.sol. I introduced a new struct & state variable:
```diff
+    struct EpochToActiveValidatorsList {
+        // (epoch => list of active validators)
+        mapping(uint64 => address[]) value;
+        // list of available epochs, sorted in asc order.
+        uint64[] epochs;
+    }

...

+   EpochToActiveValidatorsList internal _activeValidatorsListPerEpoch;
```

To reduce code duplication I introduced 3 new methods:
- `_addValidatorToActiveValidatorsList()` - Adds a validator to the active validators list in the future epoch. (If the list doesn't exist, it will be copied form the last known epoch)
- `_removeValidatorFromActiveList()` - Removes a validator from the active validators list in the future epoch. (If the list doesn't exist, it will be copied form the last known epoch)
- `getActiveValidatorsList()` - Fetches the active validators list for an epoch.

and updated the following functions that used `_activeValidatorsList` variable to use the above functions instead:
- `releaseValidatorFromJail()`
- `_addValidator()`
- `_activateValidator()`
- `_removeValidator()`
- `_disableValidator()`
- `_slashValidator()`
- `_getValidators()`

## Fetching total delegated amount from epoch
To achieve this I modified the `_totalDelegatedToValidator` to receive the epoch argument and use `_fetchValidatorSnapshot` to read the data from the epoch.
```diff
+    function _totalDelegatedToValidator(Validator memory validator, uint64 epoch) internal view returns (uint256) {
+        ValidatorSnapshot memory s = _fetchValidatorSnapshot(validator, epoch);
+        return _unpackCompact(s.totalDelegated);
+    }
```

## Gas usage

### Change in gas usage for single call
- Conditions:
- The list for the epoch doesn't exist and needs to be copied from the previous epoch.
- The gas usage measurement is taken from 1 call of the function.
- Staking contract has 1 initial validator.
  
addValidator (without perEpoch) - 159,784 gas  
addValidator (with perEpoch) - 232,252 gas  
-- difference is +72,468 gas  
  
removeValidator (without perEpoch) - 11,582 gas  
removeValidator (with perEpoch) - 123,568 gas  
-- difference is +111,986 gas  
  
activateValidator (without perEpoch) - 32,694 gas  
activateValidator (with perEpoch) - 34,306 gas  
-- difference is +1,612 gas  
  
slash (without perEpoch) - 39,122 gas  
slash (with perEpoch) - 151,112 gas  
-- difference is +111,990 gas  
  
releaseValidatorFromJail (without perEpoch) - 27,224 gas  
releaseValidatorFromJail (with perEpoch) - 121,557 gas  
-- difference is +94,333 gas  
  
### Limits
I identified 3 main functions that will consume most gas as the active validators list grows. These are:
- `getValidatorsAtEpoch()`
- `addValidator()`
- `removeValidator()`
  
I skipped `registerValidator()`, `activateValidator()`, `slash()`, `releaseValidatorFromJail()`, because the 3 functions above use more gas since they modify the active validators list in the same fashion and in addition to that perform more operations.

  
ChainConfig used for running the scripts:
- Number of main validators: type(uint32).max
- epoch len: EPOCH_LEN
- misdemeanorThreshold: 50
- felonyThreshold: 75
- validatorJailEpochLength: 1
- undelegatePeriod: 1
- minValidatorStakeAmount: 0
- minStakingAmount: 0
  

#### Original Code
| **Function** | **Max Num. of Validators** | **Gas for first Call** | **Total Gas** |
|---|---|---|---|
| addValidator | N/A | 159784 | N/A |
| getValidators | 104 | 164166 | 23538659 |
| removeValidator | 191 | 11074 | 13793057 |
  
**addValidator gas usage doesn't depend on length of active validators list.**
  
#### New Code
**The estimations below are for worst case scenarios, that's when the active validators list doesn't exist yet and has to be copied before performing the action.**

| **Function** | **Max Num. of Validators** | **Gas for first Call** | **Total Gas** |
|---|---|---|---|
| addValidator | 1072 | 232218 | 23993637 |
| getValidators | 75 | 231555 | 23034263 |
| removeValidator | 191 | 124041 | 17978959 |
  
**It's important to note that I used `type(uint32).max` as the max number of main validators.** I found that, in case of `getValidators()` reducing that number can increase the max number of validators. This means that the sorting that's done in `getValidators()` is a bottleneck of that function. So, I'd look into using a different sorting algorithm or a more efficient data structure that would allow us to keep the validators list sorted after modifications.