### PR TITLE
fix(BLK-3507): Sherlock #77

### DIFF
--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -728,11 +728,20 @@ contract Staking is IStaking, InjectorContextHolder {
         for (uint256 i = 0; i < k; i++) {
             uint256 nextValidator = i;
             Validator memory currentMax = _validatorsMap[orderedValidators[nextValidator]];
+            uint256 currentMaxIdx = i;
             for (uint256 j = i + 1; j < n; j++) {
                 Validator memory current = _validatorsMap[orderedValidators[j]];
                 if (_totalDelegatedToValidator(currentMax, epoch) < _totalDelegatedToValidator(current, epoch)) {
                     nextValidator = j;
                     currentMax = current;
+                    currentMaxIdx = j;
+                } else if (_totalDelegatedToValidator(currentMax, epoch) == _totalDelegatedToValidator(current, epoch)) {
+                    // if validators have the same total delegated amount, we prioritize the one with lower index in the active validators list (lower index = was added earlier)
+                    if (currentMaxIdx < j) {
+                        nextValidator = j;
+                        currentMax = current;
+                        currentMaxIdx = j;
+                    }
                 }
             }
             address backup = orderedValidators[i];

--- a/test/Staking-Sherlock77.t.sol
+++ b/test/Staking-Sherlock77.t.sol
@@ -1,0 +1,104 @@
+pragma solidity ^0.8.0;
+
+import {Test, console} from "forge-std/Test.sol";
+import "../contracts/Staking.sol";
+import "../contracts/SlashingIndicator.sol";
+import "../contracts/SystemReward.sol";
+import "../contracts/StakingPool.sol";
+import "../contracts/Governance.sol";
+import "../contracts/ChainConfig.sol";
+import "../contracts/RuntimeUpgrade.sol";
+import "../contracts/DeployerProxy.sol";
+import "../contracts/Tokenomics.sol";
+
+contract StakingSherlock77 is Test {
+    Staking public staking;
+    ChainConfig public chainConfig;
+
+    uint16 public constant EPOCH_LEN = 100;
+    uint256 public constant MAX_VALIDATORS = 102;
+
+    function setUp() public {
+        bytes memory ctorChainConfig = abi.encodeWithSignature(
+            "ctor(uint32,uint32,uint32,uint32,uint32,uint32,uint256,uint256)",
+            5, // number of main validators
+            EPOCH_LEN, // epoch len
+            50, // misdemeanorThreshold
+            75, // felonyThreshold
+            1, // validatorJailEpochLength
+            1, // undelegatePeriod
+            0, // minValidatorStakeAmount
+            0 // minStakingAmount
+        );
+        chainConfig = new ChainConfig(ctorChainConfig);
+
+        address[] memory valAddrArray = new address[](0);
+        uint256[] memory initialStakeArray = new uint256[](0);
+
+        bytes memory ctoStaking = abi.encodeWithSignature("ctor(address[],uint256[],uint16)", valAddrArray, initialStakeArray, 0);
+        staking = new Staking(ctoStaking);
+
+        IStaking stakingContract = IStaking(staking);
+        ISlashingIndicator slashingIndicatorContract = ISlashingIndicator(vm.addr(20));
+        ISystemReward systemRewardContract = ISystemReward(vm.addr(20));
+        IStakingPool stakingPoolContract = IStakingPool(vm.addr(20));
+        IGovernance governanceContract = IGovernance(vm.addr(20));
+        IChainConfig chainConfigContract = IChainConfig(chainConfig);
+        IRuntimeUpgrade runtimeUpgradeContract = IRuntimeUpgrade(vm.addr(20));
+        IDeployerProxy deployerProxyContract = IDeployerProxy(vm.addr(20));
+        ITokenomics tokenomicsContract = ITokenomics(vm.addr(20));
+
+        chainConfig.initManually(
+            stakingContract,
+            slashingIndicatorContract,
+            systemRewardContract,
+            stakingPoolContract,
+            governanceContract,
+            chainConfigContract,
+            runtimeUpgradeContract,
+            deployerProxyContract,
+            tokenomicsContract
+        );
+
+        staking.initManually(
+            stakingContract,
+            slashingIndicatorContract,
+            systemRewardContract,
+            stakingPoolContract,
+            governanceContract,
+            chainConfigContract,
+            runtimeUpgradeContract,
+            deployerProxyContract,
+            tokenomicsContract
+        );
+    }
+
+    function testAudit_GetValiators() public {
+        address validatorA = makeAddr("validatorA");
+        address validatorB = makeAddr("validatorB");
+        address validatorC = makeAddr("validatorC");
+
+        vm.startPrank(vm.addr(20));
+        // Set Active validator length to 2
+        chainConfig.setActiveValidatorsLength(2);
+        // Add validators
+        staking.addValidator(validatorA);
+        staking.addValidator(validatorB);
+        staking.addValidator(validatorC);
+        vm.stopPrank();
+
+        address delegator = makeAddr("Delegator");
+        deal(delegator, 40 ether);
+        vm.startPrank(delegator);
+        staking.delegate{value: 10 ether}(validatorA);
+        staking.delegate{value: 10 ether}(validatorB);
+        staking.delegate{value: 20 ether}(validatorC);
+        vm.stopPrank();
+
+        // The returned valdiators should be validatorC and validatorA
+        address[] memory validatorAddresses = staking.getValidatorsAtEpoch(1);
+        assertEq(validatorAddresses.length, 2);
+        assertEq(validatorAddresses[0], validatorC);
+        assertEq(validatorAddresses[1], validatorA);
+    }
+}


### PR DESCRIPTION
# Problem
The active main validator list returned from `getValidators()` may not be correctly sorted when at least two validators have equal `totalDelegated` amounts. This is because `totalDelegated` amount is the only sorting criteria, so when we have equal values the selection is 'random'. The audit report proposed sort validators in chronological order in this case.
  
# Solution
To fix this, when the `totalDelegated` amounts are equal, we can compare the indexes of the current & next validators in the list. less index means that the validator was added earlier to the list.