### PR TITLE
fix(BLK-3510) - Sherlock #32

### DIFF
--- a/contracts/InjectorV2.sol
+++ b/contracts/InjectorV2.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "./interfaces/IChainConfig.sol";
+import "./interfaces/IGovernance.sol";
+import "./interfaces/ISlashingIndicator.sol";
+import "./interfaces/ISystemReward.sol";
+import "./interfaces/IRuntimeUpgradeEvmHook.sol";
+import "./interfaces/IValidatorSet.sol";
+import "./interfaces/IStaking.sol";
+import "./interfaces/IRuntimeUpgrade.sol";
+import "./interfaces/IStakingPool.sol";
+import "./interfaces/IInjector.sol";
+import "./interfaces/IDeployerProxy.sol";
+import "./interfaces/ITokenomics.sol";
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts/utils/StorageSlot.sol";
+
+/** 
+    Warning: Do not use this to upgrade existing contracts. 
+    Since storage Layout is different than V1, it would break the state of the contract.
+
+    Only use when deploying new contracts.
+*/
+abstract contract InjectorContextHolderV2 is Initializable, IInjector {
+
+    // BSC compatible contracts
+    IStaking internal _stakingContract;
+    ISlashingIndicator internal _slashingIndicatorContract;
+    ISystemReward internal _systemRewardContract;
+    // CHZ defined contracts
+    IStakingPool internal _stakingPoolContract;
+    IGovernance internal _governanceContract;
+    IChainConfig internal _chainConfigContract;
+    IRuntimeUpgrade internal _runtimeUpgradeContract;
+    IDeployerProxy internal _deployerProxyContract;
+    ITokenomics internal _tokenomicsContract;
+
+    // already init (1) + ctor(1) + injector (9) = 10
+    uint256[100 - 9] private __reserved;
+
+    constructor() {}
+
+    function init() external initializer {
+        // BSC compatible addresses
+        _stakingContract = IStaking(0x0000000000000000000000000000000000001000);
+        _slashingIndicatorContract = ISlashingIndicator(0x0000000000000000000000000000000000001001);
+        _systemRewardContract = ISystemReward(0x0000000000000000000000000000000000001002);
+        // CHZ defined addresses
+        _stakingPoolContract = IStakingPool(0x0000000000000000000000000000000000007001);
+        _governanceContract = IGovernance(0x0000000000000000000000000000000000007002);
+        _chainConfigContract = IChainConfig(0x0000000000000000000000000000000000007003);
+        _runtimeUpgradeContract = IRuntimeUpgrade(0x0000000000000000000000000000000000007004);
+        _deployerProxyContract = IDeployerProxy(0x0000000000000000000000000000000000007005);
+        _tokenomicsContract = ITokenomics(0x0000000000000000000000000000000000007006);
+    }
+
+    function initManually(
+        IStaking stakingContract,
+        ISlashingIndicator slashingIndicatorContract,
+        ISystemReward systemRewardContract,
+        IStakingPool stakingPoolContract,
+        IGovernance governanceContract,
+        IChainConfig chainConfigContract,
+        IRuntimeUpgrade runtimeUpgradeContract,
+        IDeployerProxy deployerProxyContract,
+        ITokenomics tokenomicsContract
+    ) public initializer {
+        // BSC-compatible
+        _stakingContract = stakingContract;
+        _slashingIndicatorContract = slashingIndicatorContract;
+        _systemRewardContract = systemRewardContract;
+        // CHZ-defined
+        _stakingPoolContract = stakingPoolContract;
+        _governanceContract = governanceContract;
+        _chainConfigContract = chainConfigContract;
+        _runtimeUpgradeContract = runtimeUpgradeContract;
+        _deployerProxyContract = deployerProxyContract;
+        _tokenomicsContract = tokenomicsContract;
+    }
+
+    function isInitialized() external view returns (bool) {
+        // openzeppelin's class "Initializable" doesnt expose any methods for fetching initialisation status
+        StorageSlot.Uint256Slot storage initializedSlot = StorageSlot.getUint256Slot(bytes32(0x0000000000000000000000000000000000000000000000000000000000000000));
+        return initializedSlot.value > 0;
+    }
+
+    modifier onlyFromCoinbase() {
+        require(msg.sender == block.coinbase, "InjectorContextHolder: only coinbase");
+        _;
+    }
+
+    modifier onlyFromCoinbaseOrTokenomics() {
+        require(
+            msg.sender == block.coinbase || ITokenomics(msg.sender) == _tokenomicsContract,
+            "InjectorContextHolder: only coinbase or tokenomics"
+        );
+        _;
+    }
+
+    modifier onlyFromSlashingIndicator() {
+        require(msg.sender == address(_slashingIndicatorContract), "InjectorContextHolder: only slashing indicator");
+        _;
+    }
+
+    modifier onlyFromGovernance() {
+        require(IGovernance(msg.sender) == _governanceContract, "InjectorContextHolder: only governance");
+        _;
+    }
+
+    modifier onlyFromRuntimeUpgrade() {
+        require(IRuntimeUpgrade(msg.sender) == _runtimeUpgradeContract, "InjectorContextHolder: only runtime upgrade");
+        _;
+    }
+
+    modifier onlyZeroGasPrice() {
+        require(tx.gasprice == 0, "InjectorContextHolder: only zero gas price");
+        _;
+    }
+
+    function setTokenomics(address addr) public onlyFromGovernance {
+        _tokenomicsContract = ITokenomics(addr);
+    }
+}

--- a/test/RuntimeUpgrade-Sherlock32.t.sol
+++ b/test/RuntimeUpgrade-Sherlock32.t.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test, console} from "forge-std/Test.sol";
+
+import "../contracts/interfaces/IChainConfig.sol";
+import "../contracts/interfaces/IGovernance.sol";
+import "../contracts/interfaces/ISlashingIndicator.sol";
+import "../contracts/interfaces/ISystemReward.sol";
+import "../contracts/interfaces/IRuntimeUpgradeEvmHook.sol";
+import "../contracts/interfaces/IValidatorSet.sol";
+import "../contracts/interfaces/IStaking.sol";
+import "../contracts/interfaces/IRuntimeUpgrade.sol";
+import "../contracts/interfaces/IStakingPool.sol";
+import "../contracts/interfaces/IInjector.sol";
+import "../contracts/interfaces/IDeployerProxy.sol";
+import "../contracts/interfaces/ITokenomics.sol";
+
+import {RuntimeUpgrade} from "../contracts/RuntimeUpgrade.sol";
+import {InjectorContextHolderV2} from "../contracts/InjectorV2.sol";
+
+// Mock contract to simulate the EVM hook
+contract MockRuntimeUpgradeEvmHook is IRuntimeUpgradeEvmHook, Test {
+    mapping(address => bytes) public contractCode;
+
+    function upgradeTo(address contractAddress, bytes calldata byteCode) external override {
+        contractCode[contractAddress] = byteCode;
+
+        vm.etch(contractAddress, byteCode);
+    }
+
+    function getCode(address contractAddress) external view returns (bytes memory) {
+        return contractCode[contractAddress];
+    }
+}
+
+// Test system contract that implements IInjectorV2 directly
+contract TestSystemContract is InjectorContextHolderV2 {
+    uint256 public initializedValue;
+    bool public ctorCalled;
+
+    constructor() {
+        console.log("TestSystemContract constructor called !!!");
+    }
+
+    function ctor(uint256 value) external {
+        console.log("ctor called");
+        // This is the function that should be called by _invokeContractConstructor
+        initializedValue = value;
+        ctorCalled = true;
+    }
+}
+
+contract RuntimeUpgradeSherlock32 is Test {
+    RuntimeUpgrade public runtimeUpgrade;
+    MockRuntimeUpgradeEvmHook public evmHook;
+    address public dummyContractAddress;
+    address public governanceAddress;
+
+    function setUp() public {
+        // Deploy the mock EVM hook
+        evmHook = new MockRuntimeUpgradeEvmHook();
+
+        // Set up governance address
+        governanceAddress = vm.addr(5);
+
+        // Deploy RuntimeUpgrade with the mock EVM hook
+        bytes memory ctorRuntimeUpgrade = abi.encodeWithSignature("ctor(address)", address(evmHook));
+
+        runtimeUpgrade = new RuntimeUpgrade(ctorRuntimeUpgrade);
+
+        // Initialize the RuntimeUpgrade contract
+        IStaking stakingContract = IStaking(vm.addr(1));
+        ISlashingIndicator slashingIndicatorContract = ISlashingIndicator(vm.addr(2));
+        ISystemReward systemRewardContract = ISystemReward(vm.addr(3));
+        IStakingPool stakingPoolContract = IStakingPool(vm.addr(4));
+        IGovernance governanceContract = IGovernance(governanceAddress);
+        IChainConfig chainConfigContract = IChainConfig(vm.addr(6));
+        IRuntimeUpgrade runtimeUpgradeContract = IRuntimeUpgrade(address(runtimeUpgrade));
+        IDeployerProxy deployerProxyContract = IDeployerProxy(vm.addr(8));
+        ITokenomics tokenomicsContract = ITokenomics(vm.addr(9));
+
+        runtimeUpgrade.initManually(
+            stakingContract,
+            slashingIndicatorContract,
+            systemRewardContract,
+            stakingPoolContract,
+            governanceContract,
+            chainConfigContract,
+            runtimeUpgradeContract,
+            deployerProxyContract,
+            tokenomicsContract
+        );
+
+        // Set up a test contract address
+        dummyContractAddress = address(0x1234567890123456789012345678901234567890);
+    }
+
+    function test_RuntimeDeploymentShouldCallCtorAsApplyFunction() public {
+        assertEq(address(dummyContractAddress).code.length, 0, "dummyContract Address  should not have code yet");
+
+        // Create constructor parameters for our test contract
+        uint256 initValue = 42;
+        bytes memory constructorParams = abi.encodeWithSignature("ctor(uint256)", initValue);
+
+        // call runtimeUpgrade.deploySystemSmartContract
+        vm.prank(governanceAddress);
+        bytes memory runtimeCode = vm.getDeployedCode("TestSystemContract");
+        runtimeUpgrade.deploySystemSmartContract(dummyContractAddress, runtimeCode, constructorParams);
+
+        assertGt(address(dummyContractAddress).code.length, 0, "Deployed contract should have code now");
+
+        // Now check if the contract was properly initialized
+        TestSystemContract deployedContract = TestSystemContract(dummyContractAddress);
+
+        // This should be false because ctor() was never called with the initialization value
+        assertEq(deployedContract.ctorCalled(), true, "ctor() should have been called");
+        assertEq(deployedContract.initializedValue(), initValue);
+    }
+}


### PR DESCRIPTION
What I did here is I simplified the deployment process.
Since this issue is only valid when deploying new contracts I created a new Injector with empty constructor (because as stated in the findin it was not even called so it's unecessary) and removed _invokeContractConstructor (which is also useless because _ctor was always empty..)
and now if we want to deploy a new contract with a kind of "constructor" method for initialisation we can pass it as third parameter applyFunction.
Already deployed contracts wont be updated.